### PR TITLE
Fixing sentry release syntax by using an @ sign between appname and version

### DIFF
--- a/lib/handlers/sentry_handler.dart
+++ b/lib/handlers/sentry_handler.dart
@@ -107,7 +107,7 @@ class SentryHandler extends ReportHandler {
       applicationVersion += (applicationParameters['appName'] as String?)!;
     }
     if (applicationParameters.containsKey('version')) {
-      applicationVersion += " ${applicationParameters["version"]}";
+      applicationVersion += "@${applicationParameters["version"]}";
     }
     if (applicationVersion.isEmpty) {
       applicationVersion = '?';


### PR DESCRIPTION
Previously a space was used, which is incorrect. See this article for information about release naming syntax: https://docs.sentry.io/product/cli/releases/

This is important if we want to upload debug symbols using `sentry_dart_plugin` since it also names releases project@version